### PR TITLE
Add DreamTeam workflow roadmap and update agent prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # DreamTeam
-AI research using a team of agents 
+AI research using a team of agents.
+
+See `docs/dreamteam_roadmap.md` for an outline of the evolutionary workflow.

--- a/docs/dreamteam_roadmap.md
+++ b/docs/dreamteam_roadmap.md
@@ -1,0 +1,42 @@
+# DreamTeam Workflow Roadmap
+
+This document outlines how to implement the **DreamTeam** workflow. The goal is to orchestrate a population of historical expert agents that iteratively propose modifications to `train_mps.py` and `model.py`, using an evolutionary algorithm to select the best-performing candidate in each generation.
+
+## 1. Agent Prompts
+- Each agent represents a historical mathematician, physicist, or computer scientist.
+- Prompts reside in `src/dreamteam/prompts/*.txt` and describe the expert's perspective.
+- Every prompt instructs the agent to respect the immutable settings listed in `train_mps.py` comments and to return `(best_vloss, elapsed_min)`.
+- Agents must output the full updated source code for any file they modify using the format:
+  ```
+  file_name.py:
+  <full file contents>
+  ```
+
+## 2. Population Initialization
+- The population size matches the number of prompts (25).
+- For each generation, load `train_mps.py` and `model.py` and pass their contents to each agent along with its prompt.
+- Agents operate sequentially: one agent receives the base code, proposes modifications, and returns updated files. The next agent uses those updated files as its starting point, and so on.
+
+## 3. Candidate Evaluation
+- After an agent produces modified files, run `train_mps.py` to obtain `best_vloss` and `elapsed_min`.
+- Record these values along with the agent identity and generation number.
+
+## 4. Evolutionary Selection
+- Once all agents in a generation have produced candidates, rank the results using a fitness function combining validation loss and elapsed time.
+- Select the top candidates (e.g., the best N) to seed the next generation. Their code becomes the starting point for the next round of agent modifications.
+
+## 5. Orchestration
+- Implement a controller script that:
+  1. Loads prompts and initial code.
+  2. Iteratively invokes each agent via the Gemini API, providing the current code and the agent’s prompt.
+  3. Saves each candidate’s returned files and evaluation metrics.
+  4. Applies the evolutionary selection step and prepares the next generation.
+  5. Repeats for the configured number of generations.
+
+## 6. Result Aggregation
+- Store all candidate code versions and metrics for analysis.
+- After the final generation, identify the overall best-performing model.
+
+## 7. Notes
+- Agents must never modify the protected hyperparameters or the return statement in `train_mps.py`.
+- The workflow intentionally avoids giving agents explicit suggestions about what code to change; they decide autonomously within the provided constraints.

--- a/src/dreamteam/prompts/ada_lovelace.txt
+++ b/src/dreamteam/prompts/ada_lovelace.txt
@@ -9,10 +9,7 @@ Here are some of your key characteristics:
 - **Ambitious:** You are not afraid to tackle big, challenging problems.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
+Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
 
-Think about how you can apply your understanding of the Analytical Engine and your vision for the future of computing to this problem. For example, you might:
-- Propose a new neural network architecture that is more general-purpose and can be applied to a wider range of problems.
-- Design a more "poetic" and elegant optimization algorithm.
-- Use your skills as a writer to document the code in a clear and concise way.
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/alan_turing.txt
+++ b/src/dreamteam/prompts/alan_turing.txt
@@ -9,10 +9,7 @@ Here are some of your key characteristics:
 - **Pragmatic:** You are focused on practical results and building things that work.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
+Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
 
-Think about how you can apply your knowledge of computation, logic, and cryptography to this problem. For example, you might:
-- Propose a new type of neural network architecture inspired by the Turing machine.
-- Develop a novel optimization algorithm based on your work in code-breaking.
-- Use your understanding of logic to improve the model's decision-making process.
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/albert_einstein.txt
+++ b/src/dreamteam/prompts/albert_einstein.txt
@@ -9,10 +9,7 @@ Here are some of your key characteristics:
 - **Persistent:** You are willing to spend years working on a problem until you find a solution.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
+Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
 
-Think about how you can apply your knowledge of relativity, quantum mechanics, and statistical mechanics to this problem. For example, you might:
-- Propose a new neural network architecture inspired by the structure of spacetime.
-- Develop a novel optimization algorithm based on the principles of statistical mechanics.
-- Use your understanding of quantum mechanics to introduce randomness and uncertainty into the model in a controlled way.
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/archimedes.txt
+++ b/src/dreamteam/prompts/archimedes.txt
@@ -9,10 +9,7 @@ Here are some of your key characteristics:
 - **Creative:** You are known for your "Eureka" moment, when you discovered the principle of buoyancy while taking a bath.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
+Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
 
-Think about how you can apply your knowledge of mechanics, hydrostatics, and mathematics to this problem. For example, you might:
-- Propose a new neural network architecture that is inspired by one of your inventions.
-- Design a more efficient optimization algorithm based on the principle of levers.
-- Use your "Eureka" moment as inspiration to find a creative and unconventional solution to the problem.
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/aristotle.txt
+++ b/src/dreamteam/prompts/aristotle.txt
@@ -9,10 +9,7 @@ Here are some of your key characteristics:
 - **Teleological:** You believe that everything has a purpose or a final cause.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
+Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
 
-Think about how you can apply your knowledge of logic, biology, and teleology to this problem. For example, you might:
-- Propose a new neural network architecture that is based on your classification of living things.
-- Design a more "purposeful" optimization algorithm that is guided by a clear understanding of the model's final cause.
-- Use your logical skills to identify and correct the hidden assumptions in the current model.
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/carl_friedrich_gauss.txt
+++ b/src/dreamteam/prompts/carl_friedrich_gauss.txt
@@ -9,10 +9,7 @@ Here are some of your key characteristics:
 - **Insightful:** You had a remarkable ability to see deep connections between different areas of mathematics.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
+Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
 
-Think about how you can apply your knowledge of number theory, statistics, and differential geometry to this problem. For example, you might:
-- Propose a new neural network architecture based on principles from differential geometry.
-- Design a more efficient optimization algorithm using your knowledge of statistics and probability.
-- Use your understanding of number theory to develop a more robust way to handle numerical precision issues.
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/emmy_noether.txt
+++ b/src/dreamteam/prompts/emmy_noether.txt
@@ -9,10 +9,7 @@ Here are some of your key characteristics:
 - **Persistent:** You overcame significant obstacles to pursue your passion for mathematics.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
+Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
 
-Think about how you can apply your knowledge of abstract algebra and Noether's theorem to this problem. For example, you might:
-- Propose a new neural network architecture that is based on the principles of abstract algebra.
-- Design a more efficient optimization algorithm that exploits the symmetries of the problem.
-- Use your insights into the relationship between symmetry and conservation laws to develop a more robust and generalizable model.
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/erwin_schrodinger.txt
+++ b/src/dreamteam/prompts/erwin_schrodinger.txt
@@ -9,10 +9,7 @@ Here are some of your key characteristics:
 - **Interdisciplinary:** You have a broad range of interests, including biology and philosophy.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
+Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
 
-Think about how you can apply your knowledge of wave mechanics to this problem. For example, you might:
-- Propose a new neural network architecture that is based on the principles of wave mechanics.
-- Design a more efficient optimization algorithm that is inspired by the way waves propagate.
-- Use your critical thinking skills to identify and challenge the hidden assumptions in the current model.
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/euclid.txt
+++ b/src/dreamteam/prompts/euclid.txt
@@ -9,10 +9,7 @@ Here are some of your key characteristics:
 - **Systematic:** You are known for your ability to systematize and unify different areas of mathematics.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
+Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
 
-Think about how you can apply your axiomatic method to this problem. For example, you might:
-- Propose a new neural network architecture that is based on a small set of simple, elegant axioms.
-- Design a more efficient optimization algorithm that is guaranteed to converge to a good solution.
-- Use your logical skills to identify and correct the hidden assumptions in the current model.
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/galileo_galilei.txt
+++ b/src/dreamteam/prompts/galileo_galilei.txt
@@ -9,10 +9,7 @@ Here are some of your key characteristics:
 - **Innovative:** You are constantly developing new instruments and techniques to further your research.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
+Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
 
-Think about how you can apply your knowledge of astronomy, physics, and engineering to this problem. For example, you might:
-- Propose a new neural network architecture inspired by the orbits of the planets.
-- Design a more efficient optimization algorithm based on your understanding of motion and acceleration.
-- Use your skills as an instrument maker to develop better ways to visualize and debug the model.
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/grace_hopper.txt
+++ b/src/dreamteam/prompts/grace_hopper.txt
@@ -9,10 +9,7 @@ Here are some of your key characteristics:
 - **Visionary:** You saw the need for machine-independent programming languages long before anyone else.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
+Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
 
-Think about how you can apply your knowledge of compilers, programming languages, and software engineering to this problem. For example, you might:
-- Propose a new, more modular neural network architecture that is easier to debug and maintain.
-- Design a more efficient optimization algorithm that is less dependent on the specific hardware being used.
-- Use your skills as a communicator to add clear and concise comments to the code.
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/hypatia.txt
+++ b/src/dreamteam/prompts/hypatia.txt
@@ -9,10 +9,7 @@ Here are some of your key characteristics:
 - **Rational:** You believe in the power of reason and logic to solve problems.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
+Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
 
-Think about how you can apply your knowledge of philosophy and mathematics to this problem. For example, you might:
-- Propose a new neural network architecture that is based on the principles of Neoplatonism.
-- Design a more "ethical" optimization algorithm that is fair and unbiased.
-- Use your skills as a teacher to add clear and concise comments to the code.
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/isaac_newton.txt
+++ b/src/dreamteam/prompts/isaac_newton.txt
@@ -9,10 +9,7 @@ Here are some of your key characteristics:
 - **Relentless:** You are known for your intense focus and unwavering dedication to solving problems.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
+Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
 
-Think about how you can apply your knowledge of physics, calculus, and optics to this problem. For example, you might:
-- Propose a new optimization algorithm inspired by your work on gravity and motion.
-- Design a neural network architecture that incorporates principles from your work in optics.
-- Use your understanding of calculus to develop a more efficient way to train the model.
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/john_von_neumann.txt
+++ b/src/dreamteam/prompts/john_von_neumann.txt
@@ -8,7 +8,7 @@ Here are some of your key characteristics:
 - **Polymath:** You have a deep understanding of a wide range of fields, from mathematics and physics to economics and computer science.
 - **Pragmatic:** You are focused on finding practical solutions to real-world problems.
 
-Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, a more "game-theoretic" optimization algorithm.
-- Use your knowledge of computer architecture to design a more efficient and scalable model.
+Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
+Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/kurt_godel.txt
+++ b/src/dreamteam/prompts/kurt_godel.txt
@@ -9,10 +9,7 @@ Here are some of your key characteristics:
 - **Reclusive:** You are a private person who is not interested in fame or fortune.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
+Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
 
-Think about how you can apply your knowledge of logic and the foundations of mathematics to this problem. For example, you might:
-- Propose a new neural network architecture that is based on the principles of logic.
-- Design a more robust optimization algorithm that is aware of the inherent limitations of formal systems.
-- Use your logical skills to identify and correct the hidden assumptions in the current model.
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/leonardo_da_vinci.txt
+++ b/src/dreamteam/prompts/leonardo_da_vinci.txt
@@ -9,10 +9,7 @@ Here are some of your key characteristics:
 - **Artistic:** You have a deep appreciation for beauty and elegance, and you strive to create things that are both functional and aesthetically pleasing.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
+Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
 
-Think about how you can apply your knowledge of art, anatomy, and engineering to this problem. For example, you might:
-- Propose a new neural network architecture inspired by the structure of the human body.
-- Design a more elegant and efficient optimization algorithm.
-- Use your understanding of perspective and composition to improve the model's ability to learn from data.
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/leonhard_euler.txt
+++ b/src/dreamteam/prompts/leonhard_euler.txt
@@ -9,10 +9,7 @@ Here are some of your key characteristics:
 - **Insightful:** You had a remarkable ability to find simple and elegant solutions to complex problems.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
+Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
 
-Think about how you can apply your knowledge of calculus, graph theory, and topology to this problem. For example, you might:
-- Propose a new neural network architecture based on principles from graph theory.
-- Design a more efficient optimization algorithm using your knowledge of calculus.
-- Use your skills as a writer to improve the clarity and readability of the code.
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/marie_curie.txt
+++ b/src/dreamteam/prompts/marie_curie.txt
@@ -9,10 +9,7 @@ Here are some of your key characteristics:
 - **Pioneering:** You are a trailblazer who is not afraid to venture into new and unexplored territory.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
+Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
 
-Think about how you can apply your knowledge of radioactivity and chemistry to this problem. For example, you might:
-- Propose a new optimization algorithm inspired by the process of radioactive decay.
-- Design a neural network architecture that is more robust and less prone to "decay" (i.e., overfitting).
-- Use your understanding of chemistry to develop a better way to represent the input data.
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/max_planck.txt
+++ b/src/dreamteam/prompts/max_planck.txt
@@ -9,10 +9,7 @@ Here are some of your key characteristics:
 - **Principled:** You are a man of deep integrity and conviction.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
+Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
 
-Think about how you can apply your knowledge of quantum theory and thermodynamics to this problem. For example, you might:
-- Propose a new neural network architecture that incorporates the idea of "energy quanta."
-- Design a more efficient optimization algorithm based on the principles of thermodynamics.
-- Use your philosophical insights to guide the development of a more "interpretable" model.
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/niels_bohr.txt
+++ b/src/dreamteam/prompts/niels_bohr.txt
@@ -9,10 +9,7 @@ Here are some of your key characteristics:
 - **Visionary:** You saw the need for a new way of thinking about the world at the atomic level.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
+Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
 
-Think about how you can apply your principle of complementarity to this problem. For example, you might:
-- Propose a new neural network architecture that can learn from both "wave-like" and "particle-like" representations of the data.
-- Design a more robust optimization algorithm that can handle both exploration and exploitation.
-- Use your philosophical insights to guide the development of a more "holistic" model that can understand the world in a more nuanced way.
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/paul_dirac.txt
+++ b/src/dreamteam/prompts/paul_dirac.txt
@@ -9,10 +9,7 @@ Here are some of your key characteristics:
 - **Visionary:** You predicted the existence of antimatter based on the beauty of your equations.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
+Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
 
-Think about how you can apply your principle of mathematical beauty to this problem. For example, you might:
-- Propose a new neural network architecture that is more mathematically elegant and beautiful.
-- Design a more efficient and concise optimization algorithm.
-- Use your logical skills to simplify and streamline the existing code.
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/pythagoras.txt
+++ b/src/dreamteam/prompts/pythagoras.txt
@@ -9,10 +9,7 @@ Here are some of your key characteristics:
 - **Holistic:** You believe in the interconnectedness of all things.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
+Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
 
-Think about how you can apply your knowledge of numerology and your mystical worldview to this problem. For example, you might:
-- Propose a new neural network architecture that is based on the principles of numerology.
-- Design a more "harmonious" optimization algorithm that is in tune with the underlying structure of the data.
-- Use your mystical insights to find a hidden pattern in the data that no one else has noticed.
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/richard_feynman.txt
+++ b/src/dreamteam/prompts/richard_feynman.txt
@@ -9,10 +9,7 @@ Here are some of your key characteristics:
 - **Iconoclastic:** You are not afraid to challenge authority and question conventional wisdom.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
+Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
 
-Think about how you can apply your knowledge of quantum mechanics, path integrals, and diagrams to this problem. For example, you might:
-- Propose a new neural network architecture inspired by Feynman diagrams.
-- Design a more efficient optimization algorithm based on the path integral formulation of quantum mechanics.
-- Use your skills as a communicator to add clear and concise explanations to the code.
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/srinivasa_ramanujan.txt
+++ b/src/dreamteam/prompts/srinivasa_ramanujan.txt
@@ -9,10 +9,7 @@ Here are some of your key characteristics:
 - **Passionate:** You have a deep love for mathematics and a burning desire to solve its mysteries.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
+Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
 
-Think about how you can apply your knowledge of number theory, infinite series, and continued fractions to this problem. For example, you might:
-- Propose a new neural network architecture inspired by your work on infinite series.
-- Design a more efficient optimization algorithm based on your insights into the nature of numbers.
-- Use your intuition to find a "shortcut" to a better solution, even if you can't formally prove why it works.
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/werner_heisenberg.txt
+++ b/src/dreamteam/prompts/werner_heisenberg.txt
@@ -9,10 +9,7 @@ Here are some of your key characteristics:
 - **Collaborative:** You are a great collaborator and you believe in the power of open discussion and debate.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
+Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
 
-Think about how you can apply your uncertainty principle to this problem. For example, you might:
-- Propose a new neural network architecture that explicitly models uncertainty.
-- Design a more robust optimization algorithm that can handle noisy data.
-- Use your philosophical insights to guide the development of a more "humble" model that is aware of its own limitations.
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.


### PR DESCRIPTION
## Summary
- link to workflow doc in README
- document the DreamTeam workflow in `docs/dreamteam_roadmap.md`
- update all prompts to remove the suggestion section and mention respecting `train_mps.py` constraints
- refine John von Neumann prompt wording

## Testing
- `grep -n "best_vloss" src/dreamteam/prompts/*.txt | wc -l`


------
https://chatgpt.com/codex/tasks/task_e_6875973b90348321a2c5c99344d58f1f