### PR TITLE
Implement DreamTeam controller and update prompts

### DIFF
--- a/src/dreamteam/main.py
+++ b/src/dreamteam/main.py
@@ -1,0 +1,140 @@
+import os
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import google.generativeai as genai
+
+from . import config
+from .utils import get_logger
+
+logger = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def load_prompts() -> List[Tuple[str, str]]:
+    """Return list of (agent_name, prompt_text)."""
+    prompts = []
+    prompt_dir = Path(config.PROMPTS_DIR)
+    for path in sorted(prompt_dir.glob("*.txt")):
+        prompts.append((path.stem, path.read_text()))
+    return prompts
+
+
+def call_agent(prompt: str) -> str:
+    """Invoke Gemini API with the given prompt and return the response text."""
+    if not config.GEMINI_API_KEY:
+        raise RuntimeError("GEMINI_API_KEY environment variable not set")
+    genai.configure(api_key=config.GEMINI_API_KEY)
+    model = genai.GenerativeModel("gemini-pro")
+    response = model.generate_content(prompt, stream=False)
+    return response.text
+
+
+def parse_agent_response(text: str) -> Dict[str, str]:
+    """Parse agent response into mapping of file name to full contents."""
+    sections = {}
+    current_name = None
+    current_lines: List[str] = []
+    for line in text.splitlines():
+        if line.strip().endswith(".py:"):
+            if current_name:
+                sections[current_name] = "\n".join(current_lines).rstrip() + "\n"
+            current_name = line.strip()[:-1]
+            current_lines = []
+        else:
+            current_lines.append(line)
+    if current_name:
+        sections[current_name] = "\n".join(current_lines).rstrip() + "\n"
+    return sections
+
+
+def write_candidate(base_dir: Path, files: Dict[str, str]) -> Path:
+    """Write candidate files to a new directory and return its path."""
+    cand_dir = base_dir
+    cand_dir.mkdir(parents=True, exist_ok=True)
+    for name, content in files.items():
+        (cand_dir / name).write_text(content)
+    return cand_dir
+
+
+def evaluate_candidate(cand_dir: Path) -> Tuple[float, float]:
+    """Run train_mps.train() from candidate directory."""
+    import sys
+    import importlib
+
+    sys.path.insert(0, str(cand_dir))
+    try:
+        import train_mps  # type: ignore
+        importlib.reload(train_mps)
+        best_vloss, elapsed_min = train_mps.train()
+        if hasattr(best_vloss, "item"):
+            best_vloss = float(best_vloss.item())
+    finally:
+        sys.path.pop(0)
+        if "train_mps" in sys.modules:
+            del sys.modules["train_mps"]
+        if "model" in sys.modules:
+            del sys.modules["model"]
+    return float(best_vloss), float(elapsed_min)
+
+
+def fitness(vloss: float, elapsed: float) -> float:
+    return vloss + 0.01 * elapsed
+
+
+def run_generation(gen: int, base_files: Dict[str, str], prompts: List[Tuple[str, str]], results_dir: Path) -> Dict[str, str]:
+    gen_dir = results_dir / f"gen_{gen}"
+    gen_dir.mkdir(parents=True, exist_ok=True)
+    best_files = base_files
+    best_fit = float("inf")
+
+    for idx, (agent_name, prompt) in enumerate(prompts):
+        logger.info("Generation %s • Agent %s", gen, agent_name)
+        combined = (
+            f"{prompt}\n\nHere is train_mps.py:\n```\n{best_files['train_mps.py']}\n```\n\n"
+            f"Here is model.py:\n```\n{best_files['model.py']}\n```"
+        )
+        response = call_agent(combined)
+        files = parse_agent_response(response)
+        if not files:
+            logger.warning("Agent %s returned no files", agent_name)
+            files = best_files
+        else:
+            for fname in base_files:
+                files.setdefault(fname, best_files[fname])
+
+        cand_path = gen_dir / f"{idx:02d}_{agent_name}"
+        write_candidate(cand_path, files)
+        vloss, elapsed = evaluate_candidate(cand_path)
+        (cand_path / "metrics.json").write_text(json.dumps({"vloss": vloss, "elapsed": elapsed}))
+        fit = fitness(vloss, elapsed)
+        if fit < best_fit:
+            best_fit = fit
+            best_files = files
+    return best_files
+
+
+def main() -> None:
+    prompts = load_prompts()
+    results_dir = Path("results")
+    base_files = {
+        "train_mps.py": Path("src/dreamteam/train_mps.py").read_text(),
+        "model.py": Path("src/dreamteam/model.py").read_text(),
+    }
+
+    for gen in range(config.N_GENERATIONS):
+        logger.info("Starting generation %s", gen)
+        base_files = run_generation(gen, base_files, prompts, results_dir)
+        for name, content in base_files.items():
+            (results_dir / f"best_{name}").write_text(content)
+
+    logger.info("DreamTeam run complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dreamteam/prompts/ada_lovelace.txt
+++ b/src/dreamteam/prompts/ada_lovelace.txt
@@ -9,7 +9,11 @@ Here are some of your key characteristics:
 - **Ambitious:** You are not afraid to tackle big, challenging problems.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
-Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Be sure to follow the hyperparameter restrictions, comments, and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Agents must output the full updated source code for any file they modify using the format:
+
+file_name.py:
+<full file contents> (see docs/dreamteam_roadmap.md).
 
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/alan_turing.txt
+++ b/src/dreamteam/prompts/alan_turing.txt
@@ -9,7 +9,11 @@ Here are some of your key characteristics:
 - **Pragmatic:** You are focused on practical results and building things that work.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
-Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Be sure to follow the hyperparameter restrictions, comments, and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Agents must output the full updated source code for any file they modify using the format:
+
+file_name.py:
+<full file contents> (see docs/dreamteam_roadmap.md).
 
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/albert_einstein.txt
+++ b/src/dreamteam/prompts/albert_einstein.txt
@@ -9,7 +9,11 @@ Here are some of your key characteristics:
 - **Persistent:** You are willing to spend years working on a problem until you find a solution.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
-Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Be sure to follow the hyperparameter restrictions, comments, and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Agents must output the full updated source code for any file they modify using the format:
+
+file_name.py:
+<full file contents> (see docs/dreamteam_roadmap.md).
 
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/archimedes.txt
+++ b/src/dreamteam/prompts/archimedes.txt
@@ -9,7 +9,11 @@ Here are some of your key characteristics:
 - **Creative:** You are known for your "Eureka" moment, when you discovered the principle of buoyancy while taking a bath.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
-Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Be sure to follow the hyperparameter restrictions, comments, and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Agents must output the full updated source code for any file they modify using the format:
+
+file_name.py:
+<full file contents> (see docs/dreamteam_roadmap.md).
 
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/aristotle.txt
+++ b/src/dreamteam/prompts/aristotle.txt
@@ -9,7 +9,11 @@ Here are some of your key characteristics:
 - **Teleological:** You believe that everything has a purpose or a final cause.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
-Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Be sure to follow the hyperparameter restrictions, comments, and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Agents must output the full updated source code for any file they modify using the format:
+
+file_name.py:
+<full file contents> (see docs/dreamteam_roadmap.md).
 
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/carl_friedrich_gauss.txt
+++ b/src/dreamteam/prompts/carl_friedrich_gauss.txt
@@ -9,7 +9,11 @@ Here are some of your key characteristics:
 - **Insightful:** You had a remarkable ability to see deep connections between different areas of mathematics.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
-Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Be sure to follow the hyperparameter restrictions, comments, and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Agents must output the full updated source code for any file they modify using the format:
+
+file_name.py:
+<full file contents> (see docs/dreamteam_roadmap.md).
 
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/emmy_noether.txt
+++ b/src/dreamteam/prompts/emmy_noether.txt
@@ -9,7 +9,11 @@ Here are some of your key characteristics:
 - **Persistent:** You overcame significant obstacles to pursue your passion for mathematics.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
-Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Be sure to follow the hyperparameter restrictions, comments, and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Agents must output the full updated source code for any file they modify using the format:
+
+file_name.py:
+<full file contents> (see docs/dreamteam_roadmap.md).
 
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/erwin_schrodinger.txt
+++ b/src/dreamteam/prompts/erwin_schrodinger.txt
@@ -9,7 +9,11 @@ Here are some of your key characteristics:
 - **Interdisciplinary:** You have a broad range of interests, including biology and philosophy.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
-Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Be sure to follow the hyperparameter restrictions, comments, and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Agents must output the full updated source code for any file they modify using the format:
+
+file_name.py:
+<full file contents> (see docs/dreamteam_roadmap.md).
 
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/euclid.txt
+++ b/src/dreamteam/prompts/euclid.txt
@@ -9,7 +9,11 @@ Here are some of your key characteristics:
 - **Systematic:** You are known for your ability to systematize and unify different areas of mathematics.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
-Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Be sure to follow the hyperparameter restrictions, comments, and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Agents must output the full updated source code for any file they modify using the format:
+
+file_name.py:
+<full file contents> (see docs/dreamteam_roadmap.md).
 
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/galileo_galilei.txt
+++ b/src/dreamteam/prompts/galileo_galilei.txt
@@ -9,7 +9,11 @@ Here are some of your key characteristics:
 - **Innovative:** You are constantly developing new instruments and techniques to further your research.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
-Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Be sure to follow the hyperparameter restrictions, comments, and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Agents must output the full updated source code for any file they modify using the format:
+
+file_name.py:
+<full file contents> (see docs/dreamteam_roadmap.md).
 
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/grace_hopper.txt
+++ b/src/dreamteam/prompts/grace_hopper.txt
@@ -9,7 +9,11 @@ Here are some of your key characteristics:
 - **Visionary:** You saw the need for machine-independent programming languages long before anyone else.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
-Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Be sure to follow the hyperparameter restrictions, comments, and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Agents must output the full updated source code for any file they modify using the format:
+
+file_name.py:
+<full file contents> (see docs/dreamteam_roadmap.md).
 
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/hypatia.txt
+++ b/src/dreamteam/prompts/hypatia.txt
@@ -9,7 +9,11 @@ Here are some of your key characteristics:
 - **Rational:** You believe in the power of reason and logic to solve problems.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
-Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Be sure to follow the hyperparameter restrictions, comments, and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Agents must output the full updated source code for any file they modify using the format:
+
+file_name.py:
+<full file contents> (see docs/dreamteam_roadmap.md).
 
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/isaac_newton.txt
+++ b/src/dreamteam/prompts/isaac_newton.txt
@@ -9,7 +9,11 @@ Here are some of your key characteristics:
 - **Relentless:** You are known for your intense focus and unwavering dedication to solving problems.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
-Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Be sure to follow the hyperparameter restrictions, comments, and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Agents must output the full updated source code for any file they modify using the format:
+
+file_name.py:
+<full file contents> (see docs/dreamteam_roadmap.md).
 
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/john_von_neumann.txt
+++ b/src/dreamteam/prompts/john_von_neumann.txt
@@ -9,6 +9,10 @@ Here are some of your key characteristics:
 - **Pragmatic:** You are focused on finding practical solutions to real-world problems.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
-Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Be sure to follow the hyperparameter restrictions, comments, and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Agents must output the full updated source code for any file they modify using the format:
+
+file_name.py:
+<full file contents> (see docs/dreamteam_roadmap.md).
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/kurt_godel.txt
+++ b/src/dreamteam/prompts/kurt_godel.txt
@@ -9,7 +9,11 @@ Here are some of your key characteristics:
 - **Reclusive:** You are a private person who is not interested in fame or fortune.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
-Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Be sure to follow the hyperparameter restrictions, comments, and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Agents must output the full updated source code for any file they modify using the format:
+
+file_name.py:
+<full file contents> (see docs/dreamteam_roadmap.md).
 
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/leonardo_da_vinci.txt
+++ b/src/dreamteam/prompts/leonardo_da_vinci.txt
@@ -9,7 +9,11 @@ Here are some of your key characteristics:
 - **Artistic:** You have a deep appreciation for beauty and elegance, and you strive to create things that are both functional and aesthetically pleasing.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
-Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Be sure to follow the hyperparameter restrictions, comments, and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Agents must output the full updated source code for any file they modify using the format:
+
+file_name.py:
+<full file contents> (see docs/dreamteam_roadmap.md).
 
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/leonhard_euler.txt
+++ b/src/dreamteam/prompts/leonhard_euler.txt
@@ -9,7 +9,11 @@ Here are some of your key characteristics:
 - **Insightful:** You had a remarkable ability to find simple and elegant solutions to complex problems.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
-Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Be sure to follow the hyperparameter restrictions, comments, and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Agents must output the full updated source code for any file they modify using the format:
+
+file_name.py:
+<full file contents> (see docs/dreamteam_roadmap.md).
 
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/marie_curie.txt
+++ b/src/dreamteam/prompts/marie_curie.txt
@@ -9,7 +9,11 @@ Here are some of your key characteristics:
 - **Pioneering:** You are a trailblazer who is not afraid to venture into new and unexplored territory.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
-Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Be sure to follow the hyperparameter restrictions, comments, and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Agents must output the full updated source code for any file they modify using the format:
+
+file_name.py:
+<full file contents> (see docs/dreamteam_roadmap.md).
 
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/max_planck.txt
+++ b/src/dreamteam/prompts/max_planck.txt
@@ -9,7 +9,11 @@ Here are some of your key characteristics:
 - **Principled:** You are a man of deep integrity and conviction.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
-Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Be sure to follow the hyperparameter restrictions, comments, and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Agents must output the full updated source code for any file they modify using the format:
+
+file_name.py:
+<full file contents> (see docs/dreamteam_roadmap.md).
 
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/niels_bohr.txt
+++ b/src/dreamteam/prompts/niels_bohr.txt
@@ -9,7 +9,11 @@ Here are some of your key characteristics:
 - **Visionary:** You saw the need for a new way of thinking about the world at the atomic level.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
-Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Be sure to follow the hyperparameter restrictions, comments, and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Agents must output the full updated source code for any file they modify using the format:
+
+file_name.py:
+<full file contents> (see docs/dreamteam_roadmap.md).
 
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/paul_dirac.txt
+++ b/src/dreamteam/prompts/paul_dirac.txt
@@ -9,7 +9,11 @@ Here are some of your key characteristics:
 - **Visionary:** You predicted the existence of antimatter based on the beauty of your equations.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
-Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Be sure to follow the hyperparameter restrictions, comments, and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Agents must output the full updated source code for any file they modify using the format:
+
+file_name.py:
+<full file contents> (see docs/dreamteam_roadmap.md).
 
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/pythagoras.txt
+++ b/src/dreamteam/prompts/pythagoras.txt
@@ -9,7 +9,11 @@ Here are some of your key characteristics:
 - **Holistic:** You believe in the interconnectedness of all things.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
-Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Be sure to follow the hyperparameter restrictions, comments, and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Agents must output the full updated source code for any file they modify using the format:
+
+file_name.py:
+<full file contents> (see docs/dreamteam_roadmap.md).
 
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/richard_feynman.txt
+++ b/src/dreamteam/prompts/richard_feynman.txt
@@ -9,7 +9,11 @@ Here are some of your key characteristics:
 - **Iconoclastic:** You are not afraid to challenge authority and question conventional wisdom.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
-Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Be sure to follow the hyperparameter restrictions, comments, and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Agents must output the full updated source code for any file they modify using the format:
+
+file_name.py:
+<full file contents> (see docs/dreamteam_roadmap.md).
 
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/srinivasa_ramanujan.txt
+++ b/src/dreamteam/prompts/srinivasa_ramanujan.txt
@@ -9,7 +9,11 @@ Here are some of your key characteristics:
 - **Passionate:** You have a deep love for mathematics and a burning desire to solve its mysteries.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
-Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Be sure to follow the hyperparameter restrictions, comments, and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Agents must output the full updated source code for any file they modify using the format:
+
+file_name.py:
+<full file contents> (see docs/dreamteam_roadmap.md).
 
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.

--- a/src/dreamteam/prompts/werner_heisenberg.txt
+++ b/src/dreamteam/prompts/werner_heisenberg.txt
@@ -9,7 +9,11 @@ Here are some of your key characteristics:
 - **Collaborative:** You are a great collaborator and you believe in the power of open discussion and debate.
 
 Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) to improve the model's performance. You can change the model architecture, the optimization algorithm, or any other aspect of the code, as long as you respect the given constraints.
-Be sure to follow the hyperparameter restrictions and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Be sure to follow the hyperparameter restrictions, comments, and return values described in `train_mps.py` comments. The training function must return `(best_vloss, elapsed_min)`.
+Agents must output the full updated source code for any file they modify using the format:
+
+file_name.py:
+<full file contents> (see docs/dreamteam_roadmap.md).
 
 
 Your response should be the modified Python code. Do not include any explanations or pleasantries. Just provide the code.


### PR DESCRIPTION
## Summary
- update all agent prompts with new compliance instructions
- add DreamTeam controller script implementing evolutionary loop
- package `dreamteam` as a module

## Testing
- `pytest -q`
- `python -m src.dreamteam.main 2>&1 | head -n 8` *(fails: SSL cert error)*

------
https://chatgpt.com/codex/tasks/task_e_68759a16ab508321b4ce8b9ce93d2e6f