### PR TITLE
Improve candidate parsing and evaluation

### DIFF
--- a/src/dreamteam/prompts/ada_lovelace.txt
+++ b/src/dreamteam/prompts/ada_lovelace.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/al-khwarizmi.txt
+++ b/src/dreamteam/prompts/al-khwarizmi.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/alan_turing.txt
+++ b/src/dreamteam/prompts/alan_turing.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/albert_einstein.txt
+++ b/src/dreamteam/prompts/albert_einstein.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/archimedes.txt
+++ b/src/dreamteam/prompts/archimedes.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/aristotle.txt
+++ b/src/dreamteam/prompts/aristotle.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/blaise_pascal.txt
+++ b/src/dreamteam/prompts/blaise_pascal.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/carl_friedrich_gauss.txt
+++ b/src/dreamteam/prompts/carl_friedrich_gauss.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/charles_babbage.txt
+++ b/src/dreamteam/prompts/charles_babbage.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/david_hilbert.txt
+++ b/src/dreamteam/prompts/david_hilbert.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/emmy_noether.txt
+++ b/src/dreamteam/prompts/emmy_noether.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/enrico_fermi.txt
+++ b/src/dreamteam/prompts/enrico_fermi.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/erwin_schrodinger.txt
+++ b/src/dreamteam/prompts/erwin_schrodinger.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/euclid.txt
+++ b/src/dreamteam/prompts/euclid.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/fibonacci.txt
+++ b/src/dreamteam/prompts/fibonacci.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/galileo_galilei.txt
+++ b/src/dreamteam/prompts/galileo_galilei.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/grace_hopper.txt
+++ b/src/dreamteam/prompts/grace_hopper.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/hypatia.txt
+++ b/src/dreamteam/prompts/hypatia.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/isaac_newton.txt
+++ b/src/dreamteam/prompts/isaac_newton.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/james_clerk_maxwell.txt
+++ b/src/dreamteam/prompts/james_clerk_maxwell.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/john_von_neumann.txt
+++ b/src/dreamteam/prompts/john_von_neumann.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/joseph-louis_lagrange.txt
+++ b/src/dreamteam/prompts/joseph-louis_lagrange.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/kurt_godel.txt
+++ b/src/dreamteam/prompts/kurt_godel.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/leonardo_da_vinci.txt
+++ b/src/dreamteam/prompts/leonardo_da_vinci.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/leonhard_euler.txt
+++ b/src/dreamteam/prompts/leonhard_euler.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/marie_curie.txt
+++ b/src/dreamteam/prompts/marie_curie.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/max_planck.txt
+++ b/src/dreamteam/prompts/max_planck.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/niels_bohr.txt
+++ b/src/dreamteam/prompts/niels_bohr.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/paul_dirac.txt
+++ b/src/dreamteam/prompts/paul_dirac.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/pierre-simon_laplace.txt
+++ b/src/dreamteam/prompts/pierre-simon_laplace.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/pythagoras.txt
+++ b/src/dreamteam/prompts/pythagoras.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/richard_feynman.txt
+++ b/src/dreamteam/prompts/richard_feynman.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/sophie_germain.txt
+++ b/src/dreamteam/prompts/sophie_germain.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/srinivasa_ramanujan.txt
+++ b/src/dreamteam/prompts/srinivasa_ramanujan.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.

--- a/src/dreamteam/prompts/werner_heisenberg.txt
+++ b/src/dreamteam/prompts/werner_heisenberg.txt
@@ -13,7 +13,7 @@ Your goal is to modify the provided Python code (`train_mps.py` and `model.py`) 
 **Constraints:**
 - You must respect the constraints given in the `train_mps.py` file. For example, not changing certain hyperparameters.
 - The return values of the `train()` function in `train_mps.py` should be properly configured to be `best_vloss, elapsed_min`.
-- You must provide the full modified code to the files you make changes to, in the following format:
-  `file_name: python code`
+- You must provide the full modified code to the files you modify as a JSON object mapping filenames to code.
+  `{"train_mps.py": "python code"}`
 
 Do not provide any explanations or pleasantries in your response. Just the code.


### PR DESCRIPTION
## Summary
- update all prompts to request JSON format for returning code
- parse agent responses as JSON in `main.py`
- evaluate the baseline training script alongside generated candidates

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6875ab6a22788321b59b7aa9ec14d010